### PR TITLE
Update mkdocs.yml

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -45,10 +45,10 @@ plugins:
   - exporter:
       formats:
         pdf:
-          enabled: !ENV [MKDOCS_EXPORTER_PDF, true]
+          enabled: !ENV [MKDOCS_EXPORTER_PDF, false] #re-enable as true when ready
           concurrency: 8
           aggregator:
-            enabled: true
+            enabled: false #re-enable as true when ready
             output: mukurtu-user-manual.pdf
             covers: all
       buttons:


### PR DESCRIPTION
Disabling the PDF generator (noted in mkdocs.yml) to speed up local builds. We will re-enable it closer to production and for testing as needed.